### PR TITLE
fix: KafkaTester assigns partitions once, before the topic exists

### DIFF
--- a/exam-mq-kafka/src/main/java/io/github/adven27/concordion/extensions/exam/mq/kafka/KafkaTester.kt
+++ b/exam-mq-kafka/src/main/java/io/github/adven27/concordion/extensions/exam/mq/kafka/KafkaTester.kt
@@ -23,6 +23,7 @@ import java.time.Duration
 import java.time.Duration.ofMillis
 import java.time.Duration.ofSeconds
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeUnit.SECONDS
 
 @Suppress("unused", "LongParameterList", "MagicNumber")
 open class KafkaConsumeAndSendTester @JvmOverloads constructor(
@@ -102,15 +103,30 @@ open class KafkaConsumeOnlyTester @JvmOverloads constructor(
     override fun start() {
         consumerProperties[ConsumerConfig.GROUP_ID_CONFIG] = "kafka-tester-$topic"
         consumerProperties[ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG] = bootstrapServers
-        consumer = KafkaConsumer<String, String>(consumerProperties).apply {
-            assign(partitionsFor(topic).map { TopicPartition(it.topic(), it.partition()) })
-        }
+        consumer = KafkaConsumer<String, String>(consumerProperties).apply { assign(awaitPartitions()) }
         adminClient = AdminClient.create(consumerProperties)
         logger.info("Consumer started with properties:\n{}", consumerProperties)
     }
 
     override fun stop() {
         consumer.close(ofSeconds(4))
+    }
+
+    private fun KafkaConsumer<String, String>.awaitPartitions(): List<TopicPartition> {
+        val deadline = System.currentTimeMillis() + SECONDS.toMillis(KAFKA_FETCHING_TIMEOUT)
+        do {
+            val partitions = partitionsFor(topic).orEmpty()
+            if (partitions.isNotEmpty()) {
+                return partitions.map { TopicPartition(it.topic(), it.partition()) }
+            }
+            logger.debug("Topic {} has no partitions yet, waiting for metadata...", topic)
+            Thread.sleep(POLL_MILLIS)
+        } while (System.currentTimeMillis() < deadline)
+        error(
+            "Topic $topic has no partitions after $KAFKA_FETCHING_TIMEOUT s. " +
+                "A topic created on demand is not visible to the first metadata request, " +
+                "so declare it in the test environment."
+        )
     }
 
     override fun purge() = logger.debug("Purging topic {}...", topic).also {


### PR DESCRIPTION
`start()` assigned partitions from a single `partitionsFor(topic)` call:

```kotlin
consumer = KafkaConsumer<String, String>(consumerProperties).apply {
    assign(partitionsFor(topic).map { TopicPartition(it.topic(), it.partition()) })
}
```

A topic created on demand is not in the first metadata response — that call is what triggers the creation and comes back empty. The consumer then keeps an empty assignment, and every later `poll` or `seek` throws:

- `IllegalStateException: Consumer is not subscribed to any topics or assigned any partitions`
- `IllegalStateException: No current assignment for partition <topic>-0`

The embedded ZK broker used to win that race, the KRaft one does not, so specs that rely on topic auto-creation started failing in class initialisation — before a single assertion. Measured on the embedded KRaft broker: the first `partitionsFor` returns nothing, the topic shows up a moment later.

This retries the call until the partitions appear, bounded by `KAFKA_FETCHING_TIMEOUT` which the tester already uses for admin calls, and the failure message tells the reader to declare the topic in the test environment.

Verified against the embedded KRaft broker of `env-mq-kafka-embedded`: a tester on an undeclared topic fails with `2026.0.0` and passes with this change. Two theories that did not hold, for the record: `group.protocol` still defaults to `classic` in kafka-clients 4.2.1, and `allow.auto.create.topics` is `true` in both 3.1 and 4.2.