### PR TITLE
Fix ErrorListener diagnostics: a bare exception rendered without frames

### DIFF
--- a/exam-core/src/main/java/io/github/adven27/concordion/extensions/exam/core/Listeners.kt
+++ b/exam-core/src/main/java/io/github/adven27/concordion/extensions/exam/core/Listeners.kt
@@ -12,7 +12,7 @@ import io.github.adven27.concordion.extensions.exam.core.html.codeHighlight
 import io.github.adven27.concordion.extensions.exam.core.html.div
 import io.github.adven27.concordion.extensions.exam.core.html.errorMessage
 import io.github.adven27.concordion.extensions.exam.core.html.rootCause
-import io.github.adven27.concordion.extensions.exam.core.html.rootCauseMessage
+import io.github.adven27.concordion.extensions.exam.core.html.rootCauseDiagnostics
 import io.github.adven27.concordion.extensions.exam.core.html.span
 import io.github.adven27.concordion.extensions.exam.core.html.tag
 import io.github.adven27.concordion.extensions.exam.core.html.trWithTDs
@@ -208,7 +208,7 @@ class ErrorListener : ThrowableCaughtListener {
     override fun throwableCaught(event: ThrowableCaughtEvent) {
         val (id, errorMessage) = errorMessage(
             header = "Error while executing command",
-            message = event.throwable.rootCauseMessage(),
+            message = event.throwable.rootCauseDiagnostics(),
             help = help(event),
             html = PARSED_COMMANDS[event.element.getAttributeValue("cmdId")]?.let {
                 div("while executing:")(

--- a/exam-core/src/main/java/io/github/adven27/concordion/extensions/exam/core/html/Html.kt
+++ b/exam-core/src/main/java/io/github/adven27/concordion/extensions/exam/core/html/Html.kt
@@ -440,6 +440,10 @@ fun Throwable.rootCause(): Throwable {
 
 fun Throwable.rootCauseMessage() = this.rootCause().let { it.message ?: it.toString() }
 
+fun Throwable.rootCauseDiagnostics(maxFrames: Int = 10) = rootCause().let { root ->
+    root.stackTrace.take(maxFrames).joinToString(prefix = root.toString(), separator = "") { "\n    at $it" }
+}
+
 fun nu.xom.Element.addCcAttr(name: String, value: String) {
     if (value.isNotEmpty()) {
         addAttribute(Attribute(name, value).apply { setNamespace("c", ConcordionBuilder.NAMESPACE_CONCORDION_2007) })

--- a/exam-core/src/test/java/io/github/adven27/concordion/extensions/exam/core/html/HtmlTest.kt
+++ b/exam-core/src/test/java/io/github/adven27/concordion/extensions/exam/core/html/HtmlTest.kt
@@ -3,7 +3,9 @@ package io.github.adven27.concordion.extensions.exam.core.html
 import org.junit.Test
 import org.xmlunit.builder.DiffBuilder
 import org.xmlunit.diff.Diff
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class HtmlTest {
     @Test
@@ -59,6 +61,16 @@ class HtmlTest {
             """.trimIndent()
         )
         assertFalse(diff.hasDifferences(), diff.toString())
+    }
+
+    @Test
+    fun rootCauseDiagnosticsNamesTheClassAndKeepsTheTopFrames() {
+        val error = RuntimeException("wrapper", IllegalStateException(NullPointerException()))
+
+        val diagnostics = error.rootCauseDiagnostics(maxFrames = 3)
+
+        assertTrue(diagnostics.startsWith("java.lang.NullPointerException"))
+        assertEquals(3, diagnostics.lines().count { it.trimStart().startsWith("at ") })
     }
 
     private fun diff(actual: Html, expected: String): Diff {


### PR DESCRIPTION
## Problem

`ErrorListener` renders the failure via `rootCauseMessage()`, which drops the exception class when a message is present and yields a naked class name for a messageless exception. A bare Groovy NPE in a fixture shows up as `NullPointerException: null` — no frames, nothing pointing at the failing line.

## Fix

New `Throwable.rootCauseDiagnostics(maxFrames = 10)` renders the root cause `toString()` plus its top stack frames; `ErrorListener` uses it for the error block. `rootCauseMessage()` and its other call sites are untouched.

## Tests

`HtmlTest.rootCauseDiagnosticsNamesTheClassAndKeepsTheTopFrames` — a wrapped messageless NPE names the class and keeps exactly the requested number of frames.

🤖 Generated with [Claude Code](https://claude.com/claude-code)